### PR TITLE
chore: remove pa-mgwanted site

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,11 +10,5 @@
       "git_url": "https://github.com/isomerpages/mewr-eco.git",
       "site_url": "https://www.sgeco.gov.sg"
     }
-  ],
-   "2": [
-    {
-      "git_url": "https://github.com/isomerpages/pa-mgwanted",
-      "site_url": "https://www.mgs-wanted.sg"
-    }
   ]
 }


### PR DESCRIPTION
This PR removes `pa-mgwanted` from the recommender because the site no longer exists.